### PR TITLE
add PHP7.4 to the php Matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["7.0","7.1","7.2","7.3"]
+        php: ["7.0","7.1","7.2","7.3","7.4"]
     steps:
     - uses: actions/checkout@v1
     - name: enable experimental features


### PR DESCRIPTION
There is currently no PHP7.4 docker image, and this will be useful for future projects